### PR TITLE
Add withPgClient.js to "files" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/graphile-contrib/constraint-error-tags#readme",
   "files": [
     "index.js",
-    "withPgClient.js"
+    "parseTags.js"
+    "withPgClient.js",
     "src"
   ],
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/graphile-contrib/constraint-error-tags#readme",
   "files": [
     "index.js",
+    "withPgClient.js"
     "src"
   ],
   "peerDependencies": {


### PR DESCRIPTION
This change will let yarn 2 to install `withPgClient.js`,
as yarn 2 requires to explicitly define which files must be published.