### PR TITLE
Don't crash when no error tag present

### DIFF
--- a/src/ConstraintErrorTagsPlugin.js
+++ b/src/ConstraintErrorTagsPlugin.js
@@ -24,15 +24,18 @@ async function ConstraintErrorTagsPlugin(_, { pgConfig }) {
     constraintsWithErrorTags = rows
       .map(({ description, ...rest }) => {
         const error = parseTags(description).tags.error;
-        if (typeof error !== "string") {
-          throw new Error(
-            `ConstraintErrorTagsPlugin: expected error smart tag on "${rest.constraint}" to be a string, but got: ${error}.`
-          );
+        if (error) {
+          if (typeof error !== "string") {
+            throw new Error(
+              `ConstraintErrorTagsPlugin: expected error smart tag on "${rest.constraint}" to be a string, but got: ${error}.`
+            );
+          }
+          return {
+            ...rest,
+            error,
+          };
         }
-        return {
-          ...rest,
-          error,
-        };
+        return rest;
       })
       .filter(({ error }) => Boolean(error));
   });


### PR DESCRIPTION
This was crashing when I had a tag present on a constraint but no @error tag.

I removed that constraint.