### PR TITLE
Use string instead of null for errorForConstraint arg

### DIFF
--- a/src/ConstraintErrorTagsPlugin.d.ts
+++ b/src/ConstraintErrorTagsPlugin.d.ts
@@ -11,7 +11,7 @@ export const ConstraintErrorTagsPlugin: Plugin;
 
 export function errorForConstraint(
   table: string,
-  constraint: null
+  constraint: string
 ): string | null;
 
 export function handleErrors(


### PR DESCRIPTION
Resolves #6.

Uses the correct type for the `constraint` argument of the `errorForConstraint` function.

