### PR TITLE
add errors for constraints on types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ app.use(
 - `ConstraintErrorTagsPlugin` introspects all your constraints and extracts the ones with the `@error <message>` smart tag.
 - `handleErrors` violating a constraint with the above mentioned signature will replace the generic error with the `<message>` from the `@error` smart tag.
 
-## Example:
+## Example table constraint:
 
 SQL schema:
 
@@ -65,3 +65,28 @@ mutation {
 Response:
 
 GraphQL error with the message: `The user has to be at least 18 years of age.`
+
+## Example type constraint:
+
+SQL schema:
+
+```sql
+create domain strong_password as text
+constraint "symbol" check (value ~ '[!@#$%^&*()]');
+
+comment on constraint "symbol" on domain "strong_password" is '@error password must contain at least one symbol of !@#$%^&*()';
+```
+
+GraphQL mutation:
+
+```graphql
+mutation {
+  setPassword(input: {userId: "100", newPass: "weakpassword"}) {
+    clientMutationId
+  }
+}
+```
+
+Response:
+
+GraphQL error with the message: `password must contain at least one symbol of !@#$%^&*()`


### PR DESCRIPTION
I wanted to be able to get errors from constraints on a domain. This worked for me.
Is adding the 2nd function the best way, and is it okay to change the exported function name?